### PR TITLE
PLIT-transformation, and Throughput Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Buyers Backlog Visualization
 
-Version `6x`, as of November 21, 2018
+As of version `82/83`, Dec 21, 2018. 
 
 ## Purpose
 
 To visualize the backlog data for each buyer, in terms of age (amount of days passed since approval) and amount. This project also includes backlog info of the approver, as well as historical trend of mentioned metrics. 
 
-This project is designed to be a component of the data pipe, and is triggered every Monday to Friday 6am and 2pm. See documentation of the data pipe for more information. 
+Out of convenience, this project also hosts the buyer throughput dashboard, which shows the PO and PO Line count per user.
 
-The product of this project, `buyer-backlogs.html` resides with Project Chromebook, as it is being accessed by end-users through the internet. 
+This project is designed to be a component of the data pipe, and is triggered every Monday to Friday, twice every day. See documentation of the data pipe for more information. 
+
+The product of this project, `buyer-backlogs.html` and `buyer-throughput.html` resides with PLIT, as it is being accessed by end-users through the internet. 
 
 ## Install/Init
 
@@ -16,7 +18,7 @@ The product of this project, `buyer-backlogs.html` resides with Project Chromebo
 
 #### Software Packages
 
-  * `R`
+  * `R 3.5.1` 
   * `pandoc` for `rmarkdown` to `html` conversion
   * `mongodb` for accessing historical PO and REQ data
 
@@ -95,13 +97,15 @@ The roles of the files are as follows:
 | `buyer-backlogs-r` | Yes | Loads most dependencies, generates data for sorting Reqs by age. |
 | `buyer-backlogs.rmd` | Yes | RMarkdown file for rendering, includes graphs and tables definitions. |
 | `buyer-group-definition.r` | No | Defines buyer groups (INV, NINV, etc). Contains buyer names. |
+| `buyer-throughput.rmd` | Yes | RMarkdown file for rendering the buyer throughput table.
 | `data_import_manual.r` | No | Defines input file path, sets input date, and code version. Modify this file for dev/debug. |
 | `data_import.r` | No | Defines input file path, sets input date, and code version. Edited by `data_run.sh` every time upon auto refresh. |
 | `data_run.sh` | Yes | Triggered by data pipe upon auto refresh. Writes updated input file path, input file date, and code version to `data_import.r`. This file then runs `main.r` to generate the `html` output. Takes `mmddyyyy-hhmmss` as first and only parameter. |
 | `main.r` | Yes | Called by `data_run.sh`, generates the `html` output using `buyer-backlogs.rmd`. |
 | `README.md` | Yes | This file |
 | `rubix_getter.r` | Yes | Functions for accessing rubix REQ and PO apis|
-| `time_machine-graphs.r` | Yes | Reads rubix mongodb and generate data for historical trend data for Approver Backlogs and Reqs (`Plain`, `On Hold`, `Out-to-bid` for all and 90 day+ reqs) |
+| `throughput-mongo.r` | Yes | Reads rubix mongodb and generates data for buyer throughput table |
+| `time_machine-graphs.r` | Yes | Reads rubix mongodb and generates data for historical trend data for Approver Backlogs and Reqs (`Plain`, `On Hold`, `Out-to-bid` for all and 90 day+ reqs) |
 | `time_machine-mongo.r` | Yes | Writes to rubix mongodb with current data for Approver Backlogs and Reqs (`Plain`, `On Hold`, `Out-to-bid` for all and 90 day+ reqs) | 
 
 ### Intermediate Files
@@ -118,7 +122,7 @@ These intermediate `json` files are created for loading historical data from rub
 
 ### Output File(s)
 
-This project will export `buyer-backlogs.html` to the directory specified in `main.r`. It will also create a directory called `buyer-backlogs_files/` for all of its dependencies.
+This project will export `buyer-backlogs.html` and `buyer-throughput.html` to the directory specified in `main.r`. Directories named `buyer-backlogs_files/` and `buyer-throughput_files/` will be created alongside with the `html` files to store their dependencies.
 
 ### Call Flow
 

--- a/buyer-backlogs.r
+++ b/buyer-backlogs.r
@@ -27,10 +27,12 @@ backlog_raw <- readxl::read_excel(backlog_data_path, skip = 1)
 source("buyer-group-definition.r")
 
 # Buyer Category Factors, for ordering
+# Note that this factor does not include the "IGNORE" category, and thus 
+#   they should be filtered out before factorizing the Category field.
 buyer_cat_fct <- c("NINV", "SE", "INV")
 
 # Tibble of Buyers and their Categories
-buyers_cat<- bind_rows(sourcing_execs, inventory_buyers, non_inventory_buyers)
+buyers_cat<- bind_rows(sourcing_execs, inventory_buyers, non_inventory_buyers, ignore_buyers)
 
 # Date to be used as Today. Use the dynamic definition unless otherwise needed.
 date_now <- today()

--- a/buyer-throughput.rmd
+++ b/buyer-throughput.rmd
@@ -33,4 +33,4 @@ kable(throughput_lines_tibble) %>%
                        "Sourcing Exec." = throughput_row_num_vec[3]))
 ```
 
-*Counting Approved, Completed, and Dispatched POs*
+*Counting by PO Creation Date, **but** valiation by Approved, Completed, and Dispatched POs*

--- a/buyer-throughput.rmd
+++ b/buyer-throughput.rmd
@@ -1,0 +1,36 @@
+---
+output:
+  html_document:
+    self_contained: false
+---
+
+```{r include=FALSE, warning=FALSE}
+source("./throughput-mongo.r")
+```
+
+# Throughput Report of `r data_date`
+
+## PO Count
+
+```{r echo=FALSE}
+# This vector holds the number of buyers in each category for this kable,
+#   in "INV, NINV, SE" order."
+throughput_row_num_vec <- as_vector(throughput_cat_cnt_tibble[[2]])
+kable(throughput_hdr_tibble) %>% 
+  kable_styling() %>% 
+  group_rows(index = c("Inventory" = throughput_row_num_vec[1],
+                       "Non-Inventory" = throughput_row_num_vec[2],
+                       "Sourcing Exec." = throughput_row_num_vec[3]))
+```
+
+## PO Line Count
+
+```{r echo=FALSE}
+kable(throughput_lines_tibble) %>% 
+  kable_styling() %>% 
+  group_rows(index = c("Inventory" = throughput_row_num_vec[1],
+                       "Non-Inventory" = throughput_row_num_vec[2],
+                       "Sourcing Exec." = throughput_row_num_vec[3]))
+```
+
+*Counting Approved, Completed, and Dispatched POs*

--- a/main.r
+++ b/main.r
@@ -1,2 +1,3 @@
 library(rmarkdown)
 rmarkdown::render("buyer-backlogs.rmd", output_dir = '~/public/PLIT/public/')
+rmarkdown::render("buyer-throughput.rmd", output_dir = '~/public/PLIT/public/')

--- a/main.r
+++ b/main.r
@@ -1,2 +1,2 @@
 library(rmarkdown)
-rmarkdown::render("buyer-backlogs.rmd", output_dir = '~/public/Project-Chromebook/public/')
+rmarkdown::render("buyer-backlogs.rmd", output_dir = '~/public/PLIT/public/')

--- a/throughput-mongo.r
+++ b/throughput-mongo.r
@@ -1,0 +1,108 @@
+# throughput-mongo.r
+# Created by: Mickey Guo
+# Displays Buyer throughput data per calendar week
+
+# NOTE: This file depends on the "buyer-backlogs.r" file and should not be
+#         run by itself. Source the file above or run in an environment that
+#         has sourced it. 
+
+# Init, Library Imports ---------------------------------------------------
+
+library(mongolite)
+library(jsonlite)
+library(tidyverse)
+library(lubridate)
+
+# Detects current system, assumes localbox or ohio if running on linux, 
+#   otherwise use local box IP
+db_url <- if (Sys.info()[[1]] == "Linux") {"mongodb://127.0.0.1:27017"} else {"mongodb://10.108.198.117:27017"}
+environment <- "prod"
+serverlocation <- Sys.getenv("RUBIXLOCATION")
+#serverlocation <- "local"
+
+# Constructs DB name
+db_name <- paste("rubix", serverlocation, environment, sep = "-", collapse = "")
+
+# Buyer Category Order to use in this report
+buyer_cat_fct_throughput <- c("INV", "NINV", "SE")
+
+# Mongodb Connection and Query --------------------------------------------
+
+mongo_raw_po <- mongo(collection = "PO_DATA", db = db_name, url = db_url)
+
+# Querying every PO of Status "Apprv", "Comp", and "Dispt", that is created
+#   after 2018-10-15, keeping POID, Date, Buyer, and Lines field.
+mongo_query <- mongo_raw_po$find('{"PO_Date": 
+                                    {"$gt": 
+                                      {"$date": "2018-10-15T00:00:00Z"}},
+                                   "Status": 
+                                    {"$in": ["A", "C", "D"]}}',
+                                 fields = '{"PO_No": true, 
+                                            "PO_Date": true, 
+                                            "Buyer": true, 
+                                            "_id": false,
+                                            "lines": true}')
+
+mongo_po_tibble <- as_tibble(mongo_query)
+
+# Data Wrangling ----------------------------------------------------------
+
+# date/datetime -> date/datetime
+# Returns the Sunday of the given date's week, by subtracting day of week
+# from the date
+date.of.week <- function(dt) {
+  dt - wday(dt, label = FALSE) + 1
+}
+
+# DF/Tibble -> Tibble
+# Appends Buyer Category Factor, and substrings the buyer's name
+# This function will ignore the buyers defined in the "IGNORE" group
+buyer.category.buyer.names <- function(data) {
+  data %>% 
+    left_join(., buyers_cat, by = "Buyer") %>% 
+    filter(!`Category` =="IGNORE") %>% 
+    mutate_at("Category", ~parse_factor(., levels = buyer_cat_fct_throughput)) %>% 
+    arrange(`Category`, `Buyer`) %>% 
+    select(`Buyer`, everything(), -Category) %>%
+    mutate_at("Buyer", substr, start = 0, stop = 2)
+}
+
+# Changes datetimes to dates, and adds the week date
+mongo_po_tibble <- mongo_po_tibble %>% 
+  mutate_at("PO_Date", date) %>% 
+  mutate(`WeekNo` = date.of.week(`PO_Date`))
+
+# PO Count by Buyer and by Week, ignores "IGNORE" buyers
+throughput_hdr_tibble <- mongo_po_tibble %>% 
+  group_by(`Buyer`, `WeekNo`) %>% 
+  summarise(Cnt = n()) %>% 
+  ungroup(`Buyer`, `WeekNo`) %>% 
+  select(Buyer, `WeekNo`, `Cnt`) %>% 
+  spread(`WeekNo`, `Cnt`) %>% 
+  replace(is.na(.), 0) %>% 
+  buyer.category.buyer.names()
+
+# PO Line Count by Buyer and by Week, ignores "IGNORE" buyers
+throughput_lines_tibble <- mongo_po_tibble %>% 
+  mutate(`LineCnt` = map_dbl(lines, NROW)) %>% 
+  group_by(`Buyer`, `WeekNo`) %>% 
+  summarise(LineSum = sum(LineCnt)) %>% 
+  ungroup(`Buyer`, `WeekNo`) %>% 
+  select(Buyer, `WeekNo`, `LineSum`) %>% 
+  spread(`WeekNo`, `LineSum`) %>% 
+  replace(is.na(.), 0) %>% 
+  buyer.category.buyer.names()
+
+# Number of Rows per category, for auto-adjusting groups labels for the kable.
+# Joining the category table and factorizing it is repetitive, but since 
+#   categorizing and sorting and removing of the "Category" column is done
+#   in a function, it is hard to achieve similar results with less code.
+throughput_cat_cnt_tibble <- mongo_po_tibble %>% 
+  distinct(`Buyer`) %>% 
+  left_join(., buyers_cat, by = "Buyer") %>% 
+  filter(!`Category` =="IGNORE") %>% 
+  mutate_at("Category", ~parse_factor(., levels = buyer_cat_fct_throughput)) %>% 
+  group_by(Category) %>% 
+  summarize(n()) %>% 
+  arrange(Category)
+

--- a/throughput-mongo.r
+++ b/throughput-mongo.r
@@ -71,7 +71,7 @@ buyer.category.buyer.names <- function(data) {
 mongo_po_tibble <- mongo_po_tibble %>% 
   mutate_at("PO_Date", date) %>% 
   mutate(`WeekNo` = date.of.week(`PO_Date`)) %>% 
-  mutate_at("WeekNo", ~paste(month(.), day(.), sep = "/"))
+  mutate_at("WeekNo", ~format(., "%m/%d"))
 
 # PO Count by Buyer and by Week, ignores "IGNORE" buyers
 throughput_hdr_tibble <- mongo_po_tibble %>% 

--- a/throughput-mongo.r
+++ b/throughput-mongo.r
@@ -70,7 +70,8 @@ buyer.category.buyer.names <- function(data) {
 # Changes datetimes to dates, and adds the week date
 mongo_po_tibble <- mongo_po_tibble %>% 
   mutate_at("PO_Date", date) %>% 
-  mutate(`WeekNo` = date.of.week(`PO_Date`))
+  mutate(`WeekNo` = date.of.week(`PO_Date`)) %>% 
+  mutate_at("WeekNo", ~paste(month(.), day(.), sep = "/"))
 
 # PO Count by Buyer and by Week, ignores "IGNORE" buyers
 throughput_hdr_tibble <- mongo_po_tibble %>% 


### PR DESCRIPTION
Additions:

- Throughput Report on a separate webpage, obtains data from `mongodb`

Fixes:

- Changed the project's output directory to accommodate with the new host project, [PLIT](https://github.com/MBTA-Procurement-Analysts/PLIT).

Modifications:

- Updated README